### PR TITLE
[wording, ED] Remove redundant “etc.”

### DIFF
--- a/1-2.md
+++ b/1-2.md
@@ -81,7 +81,7 @@ Approximately 2-3 hours depending on demonstrations, interaction, and activities
 
 * Ask students to engage with relatives, friends, or colleagues that they may have. Ask students to gather information on which types of assistive tools and/or adaptive strategies their acquaintances use to interact with digital technology. Help students classify the tools they have learned about.
 * Guide students to focus on the abilities of people with disabilities and on how technology is part of their everyday life. Coach students towards thinking about people first and promote an inclusive approach. Use the resource [Interacting with People with Disabilities](http://www.uiaccess.com/accessucd/interact.html) for further information. 
-* Present some assistive technologies and adaptive strategies, such as captions, text customization (e.g. font size, color, spacing, etc.), specialized keyboards, audio descriptions, screen readers, and screen magnifiers.
+* Present some assistive technologies and adaptive strategies, such as captions, text customization (e.g. font size, color, spacing), specialized keyboards, audio descriptions, screen readers, and screen magnifiers.
 * Demonstrate use of assistive technology by experienced users, to avoid misunderstanding (these tools can be complex and not intended for casual use). Ask them to show the difference between accessible and inaccessible content.
 * Encourage learners to try some adaptive strategies following expert advice by exploring different settings in web browsers and operating systems.
 * Discuss with students various accessibility design features of common sites or devices, as well as access barriers that people experience with digital content. Help them understand the everyday impact of design decisions on people with disabilities.
@@ -90,8 +90,8 @@ Approximately 2-3 hours depending on demonstrations, interaction, and activities
 
 #### Homework Ideas
 
-* Ask students to explore the use of assistive technologies to perform a task, such as reading the news, making a purchase, interacting in social networks, etc. Instruct them that their experiences are not those of an assistive technology everyday user.
-* Ask students to go to three different types of websites (e.g., shopping site, banking site, entertainment site) and to identify three access barriers from each of the three sites. Ask students to creatively explain how better design may remove those barriers found.
+* Ask students to explore the use of assistive technologies to perform a task, such as reading the news, making a purchase, interacting in social networks. Instruct them that their experiences are not those of an assistive technology everyday user.
+* Ask students to go to three different types of websites (e.g. shopping site, banking site, entertainment site) and to identify three access barriers from each of the three sites. Ask students to creatively explain how better design may remove those barriers found.
 * Ask students to contact a person with a disability and interview them about what access barriers they encounter when trying to access digital content or applications. Students will write up a summary of the interview and share with other students in class.
 
 {% include excol.html type="end" %} 
@@ -142,7 +142,7 @@ Learners should be able to:
 * <a id="people-use-web" href="https://www.w3.org/WAI/people-use-web/">How People with Disabilities Use the Web</a> &mdash; provides stories of people with diverse disabilities using the Web; enumerates different types of disabilities and some of the barriers that people encounter using the Web; and introduces different types of assistive tools and adaptive strategies that some people use.
 * <a id='perspectives' href="https://www.w3.org/WAI/perspective-videos/">Web Accessibility Perspectives (videos)</a> &mdash; series of 10 videos, each of around 1 minute duration, that highlight different types of accessibility features and how they impact people with disabilities and other users. For example, one video introduces colors with good contrast and how it benefits many people.
 * <a id="better-web-browsing" href="https://www.w3.org/WAI/users/browsing">(Work in progress) Better Web Browsing: Tips for Customizing Your Computer</a> &mdash; provides references to resources to help users customize their particular web browser and computer setup, to improve their accessibility experience. It lists different types of settings and assistive tools that are available on different systems.
-* <a id="components" href="https://www.w3.org/WAI/fundamentals/components/">Essential Components of Web Accessibility</a> &mdash; explains key terms, and the inter-relation between different components of web accessibility (e.g., web technologies, authoring tools, browsers, etc.).
+* <a id="components" href="https://www.w3.org/WAI/fundamentals/components/">Essential Components of Web Accessibility</a> &mdash; explains key terms, and the inter-relation between different components of web accessibility (e.g. web technologies, authoring tools, browsers).
 
 {% comment %}
 


### PR DESCRIPTION
When using “such as” or “e.g.” it is already clear that you only have examples and that there is more.