### PR TITLE
[ED-strongly suggested] Intro/Learning Outcomes editorial changes

### DIFF
--- a/1-4.md
+++ b/1-4.md
@@ -19,20 +19,21 @@ navigation:
 ## Introduction
 {:.no-display}
 
-Courses based on this unit are expected to:
-* introduce students to the accessibility principles: Perceivable, Operable, Understandable, and Robust.
-* provide students with an overview on the W3C accessibility standards and guidelines
-* relate the standards' requirements (success criteria) to preliminary accessibility checks. 
+Courses based on this unit should:
+
+* introduce students to the accessibility principles: “Perceivable”, “Operable”, “Understandable”, and “Robust”.
+* provide students with an overview on the W3C accessibility standards
+* relate the requirements of the standards (their “success criteria”) to preliminary accessibility checks
 
 ## Learning Outcomes
 
 Students should be able to:
 
-* Define the terms “Perceivable”, “Operable”, “Understandable”, and “Robust” (POUR) as related to web accessibility guidelines
-* Define the scope of Web Content (WCAG), Authoring Tools (ATAG), User Agent (UAAG), and Accessible Rich Internet Application (WAI-ARIA) Guidelines and their relevance for accessibility
-* Explain how W3C accessibility standards are developed and recognize their adoption by policy makers internationally
-* Describe different design and development requirements and examples for each
-* Carry out first accessibility checks of simple web pages
+* define the terms “Perceivable”, “Operable”, “Understandable”, and “Robust” (called the “POUR principles”) related to web accessibility guidelines
+* define the scope of Web Content, Authoring Tools, and User Agent Accessibility Guidelines (WCAG, UAAG, and ATAG) as well as the Accessible Rich Internet Application (WAI-ARIA) specification and their relevancy for accessibility
+* explain how W3C accessibility standards are developed and recognize how they are adopted by policy makers internationally
+* describe different design and development requirements and examples for each standard
+* carry out accessibility checks of simple web pages
 
 ## Competencies 
 


### PR DESCRIPTION
- Try to align the terminology in both sections
- Make sure that the lists follow the same format (lowercase first
letter…)
- remove passive voice
- change “standards and guidelines” to “standards” to encompass non
XXAG specs
- Quote marks around POUR principles in the first bullet point
- Making clear that the success criteria are the requirements of the
standard (and removing the complicated to read “standards’
requirements”
- Give more context for the POUR acronym
- Group the XXAG abbreviations for better readability and to make
clear that ARIA is not “Guidelines” (This might be pedantic but
guidelines, standards and specifications are often confused, so I like
to be precise.)
- Add “standard” to be more specific what students should be able to do
- Remove “first” from the accessibility checks sentence because it
might be misunderstood.