### PR TITLE
Principles Section Editorial Changes

### DIFF
--- a/1-4.md
+++ b/1-4.md
@@ -64,14 +64,15 @@ The following topics help achieve the learning outcomes. Adapt the sequence of t
 
 {% include excol.html type="middle" %}
 
-Introduce the terms “Perceivable”, “Operable”, “Understandable”, and “Robust” (POUR). Use the resource [Accessibility Principles](https://www.w3.org/wai/accessibility-principles/) 
+Introduce the terms “Perceivable”, “Operable”, “Understandable”, and “Robust” (called the "POUR principles"). Use the resource [Accessibility Principles](https://www.w3.org/wai/accessibility-principles/).
 
 #### Learning Outcomes
 
 Students should be able to:
-* Identify the terms “Perceivable”, “Operable”, “Understandable”, and “Robust” as the principles of accessibility
-* Explain some requirements from each of the principles
-* List some examples of accessibility requirements for each of the principles
+
+* identify the terms “Perceivable”, “Operable”, “Understandable”, and “Robust” as the principles of accessibility
+* explain some requirements from each principle
+* list examples of accessibility requirements for each principle
 
 {% comment %}
 
@@ -83,15 +84,15 @@ Approximately 30-45 minutes.
 
 #### Teaching Ideas
 
-* Introduce students to the terms “Perceivable”, “Operable”, “Understandable”, and “Robust”. Explain that each of the standards has a set of requirements pertaining to each of these principles.
-* Introduce the requirements for each of these principles. For instance, refer to requirements regarding Distinguishability. Emphasize how such requirements are essential for people with disabilities but also benefit all web users.
-* Reflect with students on which of these principles relate more to their daily tasks or activities and how they could apply such principles in their daily job.
+* Introduce students to the terms “Perceivable”, “Operable”, “Understandable”, and “Robust”. Explain that each of the standards has a set of requirements related to each of these principles.
+* Introduce the requirements for each principle. For instance, refer to requirements to make content distinguishable and emphasize how they are essential for people with disabilities but also benefit all web users.
+* Reflect with students how these principles relate to their daily tasks or activities and how they could apply them in their work.
 
 #### Homework Ideas
 
 * Ask students to write a short essay commenting on the four principles of web accessibility and their corresponding guidelines.
-* Select at least three accessibility requirements and ask students to determine which principle they belong to. Encourage them to list at least two guidelines related to the requirement you have chosen. For instance, use the requirement "Text alternatives for non-text content".
-* Have the students choose three requirements (or success criteria), one each from Perceivable, Operable, and Understandable. Students will define the requirement in their own words. For each of the requirements, students will find one example of a web site page that is not following that requirement. Share definition and examples with other students.
+* Select three or more accessibility requirements. Ask students to determine which principle they belong to. Encourage them to list at least two guidelines related to the chosen requirements. For instance, use the requirement "Text alternatives for non-text content".
+* Have the students choose three requirements (or success criteria), one each from “Perceivable”, “Operable”, and “Understandable”. Let them define the requirements in their own words and find example web pages that do _not_ follow the requirements. Share those definitions and examples with other students.
 
 {% include excol.html type="end" %}
 


### PR DESCRIPTION
- clarify POUR principles
- Add period after “Use the resource Accessibility Principles” sentence
- Lowercase start of list “students should be”
- Simplify sentences with “each of the principles” to “each principle”
- Change pertaining to related as it is a more common word
- Distinguishability is a complicated word and barely used. We also
need to say what is distinguished.
- Use “three or more” instead of “at least three” as it has less
cognitive load.
- Simplify new list item.

**Open:**

> * Select three or more accessibility requirements. Ask students to
determine which principle they belong to. Encourage them to list at
least two guidelines related to the chosen requirements. For instance,
use the requirement "Text alternatives for non-text content".

I think we should list three requirements with good coverage.