### PR TITLE
[ED-strongly suggested] Standards and Guidelines Topic

### DIFF
--- a/1-4.md
+++ b/1-4.md
@@ -101,18 +101,18 @@ Approximately 30-45 minutes.
 
 {% include excol.html type="middle" %}
 
-Introduce the scope of the W3C accessibility standards. It includes desktop and mobile websites and applications, authoring tools, and user agents. Use the resource [W3C Accessibility Standards Overview](https://www.w3.org/wai/standards-guidelines/) 
+Introduce the scope of the W3C accessibility standards. It includes desktop and mobile websites and applications, authoring tools (like Content Management Systems, CMS), and user agents (like web browsers). Use the resource [W3C Accessibility Standards Overview](https://www.w3.org/wai/standards-guidelines/).
 
-Go through the milestones in WAI standard's development. Use the resource [How WAI Develops Accessibility Standards through the W3C Process](https://www.w3.org/wai/standards-guidelines/w3c-process) 
+Go through the milestones in WAI’s standards development. Use the resource [How WAI Develops Accessibility Standards through the W3C Process](https://www.w3.org/wai/standards-guidelines/w3c-process/).
 
 #### Learning Outcomes
 
 Students should be able to:
 
-* List the current W3C accessibility standards: WCAG, ATAG, UAAG, and WAI-ARIA
-* Describe their structure, principles, guidelines, requirements, and the type of audience and components they address
-* Explain the interrelations between these standards, web technologies, and accessibility components
-* Describe the public approach of the standards' development process, with involvement from organizations of people with disabilities, industry, public bodies, and interested individuals. 
+* list the current main W3C accessibility standards: WCAG, ATAG, UAAG, and WAI-ARIA
+* describe their structure, principles, guidelines, requirements, and the type of audience and components they address
+* explain how these standards, web technologies, and accessibility components relate
+* describe how the public approach of standards development involves people with disabilities, industry, public bodies, and other individuals. 
 
 {% comment %}
 
@@ -124,17 +124,17 @@ Approximately 30-45 minutes.
 
 #### Teaching Ideas
 
-* Explain the overall structure and sections of these standards. Relate them with web technologies and components such as HTML, authoring tools, web browsers, assistive tools, and media players. Use the resource [Essential Components of Web Accessibility](https://www.w3.org/WAI/fundamentals/components/)
-* Highlight that W3C updates the standards periodically. Underline that updates respond to changes in technologies, components, and user needs.
+* Explain the overall structure and sections of the standards. Relate them with web technologies and components such as HTML, authoring tools, web browsers, assistive tools, and media players. Use the resource [Essential Components of Web Accessibility](https://www.w3.org/WAI/fundamentals/components/).
+* Highlight that W3C updates standards periodically. Underline that updates respond to changes in technologies, components, and user needs.
 * Refer to the inclusion of W3C accessibility standards in different policies and standards internationally.
 * Explain that WAI develops these standards following the W3C process, with involvement of representation of people with disabilities, industry, public, and research bodies, and individual experts.
-* Discuss with students the specific role of each of the standards mentioned and encourage them to reflect on which of them relates to their environment.
+* Discuss with students the specific role of each of the standards mentioned and encourage them to reflect on how the standards relate to their environment.
 
 #### Homework Ideas
 
-* Ask students to write a short paragraph for each of the standards. Encourage them to define its scope and overall structure and to mention the web technologies and components they address.
-* Identify several accessibility issues. Ask students to decide which standard covers these issues and which specific section of the standard they belong to.
-* Ask students to comment on accessibility laws and policies in their region, if any. Ask them to specify if they have been inherited from W3C. If not, encourage them to give a brief overview of which similarities and differences they have with respect to the W3C accessibility standards. 
+* Ask students to write a short paragraph about each standard. Encourage them to point out their scope and overall structure and to mention the web technologies and components they address.
+* Describe several accessibility issues. Ask students to decide which standard and specific section covers each issue.
+* Ask students to comment on accessibility laws and policies in their region, if any. Ask them to specify if they have been adopted from W3C standards. If not, encourage them to give a brief overview of similarities and differences to the W3C accessibility standards. 
 
 {% include excol.html type="end" %}
 


### PR DESCRIPTION
- add some context to Authoring Tools and User Agents
- some minor grammar fixes
- Add “main” to current W3C accessibility standards as the AOM, AAMs
and other standards might also be seen as accessibility standards, but
we don’t mention them here at all.
- remove “interrelations between“ because it is a long word ;-)
- Making sure it is clear that people with disabilities are involved
in the standards process, not “only” their organizations
- Under homework, mainly trying to be more specific. Also replacing
“inherited from W3C” with “adopted from W3C standards”.