### PR TITLE
[ED-Low] Module 2 --Minor editorial tweaks

### DIFF
--- a/content/1-2.md
+++ b/content/1-2.md
@@ -22,7 +22,7 @@ navigation:
 Courses based on this module:
 
 * Explore assistive technologies, adaptive strategies, and accessible design principles in more detail.
-* Study the interdependencies between components of web accessibility (web browsers, authoring tools, web designers and developers, accessibility platforms, and operating systems).
+* Study the links between components of web accessibility (web browsers, authoring tools, web designers and developers, accessibility platforms, and operating systems).
 
 ## Learning Outcomes
 
@@ -31,7 +31,7 @@ Students should be able to:
 * Recognize the broad diversity of people with disabilities.
 * List different types of assistive technologies and adaptive strategies.
 * Recognize the impact of design decisions on accessibility for people.
-* Explain some of the interdependencies between components of web accessibility.
+* Explain some of the links between components of web accessibility.
 
 ## Competencies
 
@@ -43,7 +43,7 @@ Students:
 
 Instructors:
 
-* Good understanding of the interdependencies of web accessibility components.
+* Good understanding of the links between web accessibility components.
 * In-depth knowledge of how people with disabilities use the Web (including assistive technologies and adaptive strategies) and of accessibility principles.  
     
 ## Topics to Teach
@@ -73,14 +73,14 @@ Students should be able to:
 
 Optional ideas to teach the learning outcomes:
 
-* Ask students to engage with people with disabilities, such as relatives, friends, or colleagues. Ask students to gather information on the assistive technologies and/or adaptive strategies their acquaintances use to interact with digital technology. Help students classify the tools they learn about.
+* Ask students to engage with people with disabilities, such as relatives, friends, or colleagues. Ask students to gather information on the assistive technologies and/or adaptive strategies used to interact with digital technology. Help students classify the tools they learn about.
 * Guide students to focus on the abilities of people with disabilities and on how technology is part of their everyday life. Coach students towards thinking about people first and promote an inclusive approach. For further information, refer to [Interacting with People with Disabilities](http://www.uiaccess.com/accessucd/interact.html). 
-* Present some assistive technologies and adaptive strategies, such as captions, text customization (e.g., font size, color, or spacing), specialized keyboards, audio descriptions, screen readers, and screen magnifiers. Mention things like eyeglasses as a type of assistive device.
-* Demonstrate use of assistive technology by experienced users, to avoid misuse. Note that some tools are not easy for novices. Ask demonstrators to show examples of accessible content first, then inaccessible content.
+* Present some assistive technologies and adaptive strategies, such as captions, text customization (e.g., font size, color, or spacing), specialized keyboards, audio descriptions, screen readers, and screen magnifiers. Mention things like glasses as a type of assistive technology.
+* Demonstrate the use of assistive technology by experienced users. Note that some tools are not easy for novices. Ask users to show examples of accessible content first, then inaccessible content.
 * Encourage students to try some adaptive strategies following expert advice by exploring different settings in web browsers and operating systems.
 * Discuss with students various accessibility design features of common sites or devices, as well as access barriers that people experience with digital content.
 
-**Important**: Avoid portraying disabilities as being limiting, uncomfortable, or heroic. For information on avoiding clichés and myths, see [Interacting with People with Disabilities {% include_cached external.html %}](http://www.uiaccess.com/accessucd/interact.html).
+**Important**: Avoid showing disabilities as being limiting, uncomfortable, or heroic. For information on avoiding clichés and myths, see [Interacting with People with Disabilities {% include_cached external.html %}](http://www.uiaccess.com/accessucd/interact.html).
 
 #### Ideas to Assess Knowledge
 
@@ -88,7 +88,7 @@ Optional ideas to support assessment:
 
 * Report &mdash; Students write a report of around 300 words describing some of the design features that one of the assistive technologies they learned about relies on to function. Assess students' capacity to identify how people with disabilities rely on specific features to use the Web.
 * Practice &mdash; Students go to three different types of websites (e.g., shopping site, banking site, or entertainment site) and identify accessibility features from those they learned about. Assess students' capacity to explain how better design can enhance those features.
-* Interview &mdash; Students contact a person with a disability and interview them about what accessibility features and barriers they encounter when trying to access digital content or applications, as well as how up-to-date they are with technology. Assess students' capacity to identify such features and barriers and link them to the knowledge they acquired.
+* Interview &mdash; Students contact a person with a disability and interview them. Explore what accessibility features and barriers they encounter when trying to access digital content or applications, as well as how up-to-date they are with technology. Assess students' capacity to identify such features and barriers and link them to the knowledge they acquired.
 
 {% include excol.html type="end" %} 
 
@@ -98,23 +98,23 @@ Optional ideas to support assessment:
 
 {% include excol.html type="middle" %} 
 
-Explain that web accessibility depends on several components working together:  content, browsers, authoring tools, web designers and developers, and more. Briefly note that there are W3C Standards for the different components. (The standards are explored in detail in [Module 4](/curricula/introduction-to-web-accessibility/principles-standards-and-checks/).) For an explanation of the components and interdependencies, see [Essential Components of Web Accessibility](/fundamentals/components/).
+Explain that web accessibility depends on several components working together: content, browsers, authoring tools, web designers and developers, and more. Briefly note that there are W3C Standards for the different components. (The standards are explored in detail in [Module 4](/curricula/introduction-to-web-accessibility/principles-standards-and-checks/).) For an explanation of the components and how they link together, see [Essential Components of Web Accessibility](/fundamentals/components/).
 
 #### Learning Outcomes
 
 Students should be able to:
 
 * Describe the components that contribute to accessibility.
-* Explain some of the interdependencies between the components.
-* Describe the impact that some content technologies have on digital accessibility.
+* Explain some of the links between the components.
+* Describe the impact that some Web technologies have on digital accessibility.
 * Identify W3C standards that address the components.
 
 #### Teaching Ideas
 
 Optional ideas to teach the learning outcomes:
 
-* Based on the previously taught topics, reflect with students on the interdependencies between assistive technologies, adaptive strategies, and digital content. Guide them to realize how one relies on the other and how using different combinations of tools may yield different user experiences.
-* Explore with students some of the accessibility features built into content technologies, such as HTML, for example, headings and lists. Ask students to reflect on how these relate to prior observations they made.
+* Based on the previously taught topics, reflect with students on the links between assistive technologies, adaptive strategies, and digital content. Guide them through how one relies on the other and how using different combinations of tools may yield different user experiences.
+* Explore with students some of the accessibility features built into Web technologies. For example, HTML headings and lists. Ask students to reflect on how these relate to prior observations they made.
 * Reflect with students on the roles of browsers and media players; for example, explain that a media player needs to support captions or audio descriptions. Encourage them to explore accessibility support in different tools.
 * Reflect with students on the role of authoring tools, such as Content Management Systems (CMS). For example, does their preferred social media platform include options to provide text alternatives for images?
 * Introduce potential options to improve accessibility in different situations. Guide students to reflect on the implications of using a more accessible browser, exploring accessibility platforms and APIs, and requiring accessibility during procurement.
@@ -124,8 +124,8 @@ Optional ideas to teach the learning outcomes:
 Optional ideas to support assessment:
 
 * Reflective Journal &mdash; Students reflect on specific types of accessibility features and barriers, and how they relate to the different components of web accessibility. Assess students' capacity to recognize how components work together to improve accessibility.
-* Guided Quiz &mdash; Students identify three websites where one accessibility feature in content technology is being used. For example, Where are ordered and unordered lists used effectively? Where is heading structure in place? Assess students' capacity to identify instances of content that promote accessibility features.
-* Presentation &mdash; Students use a variety of websites with three different browsers and assistive technologies. Students explain any differences between accessing the  content with the different browsers and assistive technologies. Students share with others which browser they think works best and why. Assess students' capacity to identify the way user agents and assistive technologies render content has an impact on accessibility.
+* Guided Quiz &mdash; Students identify three websites where one accessibility feature in Web technology is being used. For example, Where are ordered and unordered lists used effectively? Where is heading structure in place? Assess students' capacity to identify instances of content that promote accessibility features.
+* Presentation &mdash; Students use a variety of websites with three different browsers and assistive technologies. Students explain any differences between accessing the content with the different browsers and assistive technologies. Students share with others which browser they think works best and why. Assess students' capacity to identify the way user agents and assistive technologies render content has an impact on accessibility.
 
 {% include excol.html type="end" %} 
 
@@ -134,9 +134,9 @@ Optional ideas to support assessment:
 Optional ideas to support assessment:
 
 * Practice &mdash; Students perform basic tasks with assistive technologies, such as using the tab key to navigate different interfaces or using screen readers' navigation quick keys. Assess students' capacity to interact with assistive technologies.
-* Multiple Choice Questions &mdash; From a list of 10 - 15 accessibility barriers, students decide for each of them if they are related to the content, the underlying technology, the user agent, and/or assistive technology. Assess students' capacity to relate the different components of web accessibility.
-* Presentation &mdash; Students describe how some adaptive strategies may benefit other users as well, such as ageing individuals. Assess students' capacity to identify some use patterns and relate them to different user groups, regardless of disability.
-* Report &mdash; Students identify the components of web accessibility and explain how they relate with each other to create an accessible experience. For example, students reflect on how a content creator provides a text alternative that is properly coded, supported by the browser, and rendered to the user via their assistive technology.
+* Multiple Choice Questions &mdash; From a list of 10 - 15 accessibility barriers. Students decide for each of them if they are related to the content, the underlying technology, the user agent, and/or assistive technology. Assess students' capacity to relate the different components of web accessibility.
+* Presentation &mdash; Students describe how some adaptive strategies may benefit other users as well, such as older adults. Assess students' capacity to identify some patterns or use and relate them to different user groups, regardless of disability.
+* Report &mdash; Students identify the components of web accessibility and explain how they relate to each other to create an accessible experience. For example, students reflect on how a content creator provides a text alternative that is properly coded, supported by the browser, and rendered to the user via their assistive technology.
 
 ## Teaching Resources
 


### PR DESCRIPTION
* 'Interdependencies' is too long a word - I have used 'links' instead. I appreciate that this isn't quite the same as interdependencies but close enough and it is much shorter and easier to deal with.
* 'Aquaintences' is too long a word
* Not sure what the phase 'to avoid misuse' is trying to do.
* Suggesting 'Web technologies' rather than 'content technologies' as the latter isn't really explained.
* 'Ageing individuals' - by definition all individuals are ageing - I am assuming this means 'older adults'.
* The phrase 'assistive technology' is used and then changed to 'assistive device' - suggested change for consistency.
* 'Glasses' seems a bit simpler and less archaic than 'eyeglasses' - the term eyeglass may be more common in non-British English though.
* 'Demonstrators' is overly long
* 'Portraying' seems a bit of a complex word
* Shortening a long sentence