### PR TITLE
Fix typos

### DIFF
--- a/content/2-3.md
+++ b/content/2-3.md
@@ -58,7 +58,7 @@ Instructors:
   * Html [`alt`](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-alt) attribute.
   * HTML `longdesc` attribute.
   *  [ARIA `img`](https://www.w3.org/TR/wai-aria-1.1/#img) role.
-  * [`aria-label`](https://www.w3.org/TR/wai-aria-1.1/#aria-label), [`aria-labeledby`](https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby), and [`aria=-describedby`](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby) elements.
+  * [`aria-label`](https://www.w3.org/TR/wai-aria-1.1/#aria-label), [`aria-labeledby`](https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby), and [`aria-describedby`](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby) elements.
   * [`Figure`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element) and [`figcaption`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element) elements.
 * In-depth knowledge of:
   * [What is Web Accessibility)](https://www.w3.org/WAI/curricula/introduction-to-web-accessibility/what-is-web-accessibility/).

--- a/content/2-3.md
+++ b/content/2-3.md
@@ -61,7 +61,7 @@ Instructors:
   * [`aria-label`](https://www.w3.org/TR/wai-aria-1.1/#aria-label), [`aria-labeledby`](https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby), and [`aria-describedby`](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby) elements.
   * [`Figure`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element) and [`figcaption`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element) elements.
 * In-depth knowledge of:
-  * [What is Web Accessibility)](https://www.w3.org/WAI/curricula/introduction-to-web-accessibility/what-is-web-accessibility/).
+  * [What is Web Accessibility](https://www.w3.org/WAI/curricula/introduction-to-web-accessibility/what-is-web-accessibility/).
   * [People and Digital Technology](https://www.w3.org/WAI/curricula/introduction-to-web-accessibility/people-and-digital-technology/).
   * [Principles, Standards, and Checks](https://www.w3.org/WAI/curricula/introduction-to-web-accessibility/principles-standards-and-checks/).
 

--- a/content/2-3.md
+++ b/content/2-3.md
@@ -172,7 +172,7 @@ Students should be able to:
   
 #### Teaching Ideas for Topic
 
-Optional ideas to support assessment.
+Optional ideas to teach the learning outcomes:
 
 * Explain that sometimes alternative texts are not enough to convey the information of an image. Discuss ways to provide additional descriptions for complex images and groups of images, for example `fig` and `figcaption`, `aria-describedby` or `longdesc`. For reference on how to describe complex images see the WAI website tutorials, [Complex images](https://www.w3.org/WAI/tutorials/images/complex/).
 * Explain that many visual effects can now be achieved by using CSS Transforms and CSS Fonts technologies, instead of embedding an image file with text into a web page. For reference, see the WAI website tutorials, section [Using CSS](https://www.w3.org/WAI/tutorials/images/textual/#using-css3).


### PR DESCRIPTION
Fixing a typo in "aria=-describedby" and a lost parenthesis 